### PR TITLE
fix: 인증 불필요 경로에서 리프레시 토큰 기반 액세스토큰 재발급 예외 처리

### DIFF
--- a/src/lib/api/fetchClient.api.ts
+++ b/src/lib/api/fetchClient.api.ts
@@ -22,19 +22,30 @@ export const cookieFetch = async <T = any>(path: string, options: RequestInit = 
   };
 
   let response = await request();
-  // ✅ 무한 루프 방지: 리프레시 토큰 요청이면 다시 시도하지 않음
+
   const isRefreshRequest = path === "/auth/refresh-token";
 
-  // 1차 요청이 실패하고 401인 경우 → 리프레시 토큰으로 재발급
-  if (response.status === 401 && !isRefreshRequest) {
+  // 예외 경로: 랜딩페이지(/), /signup, /signup/*, /login, /login/*
+  let isExceptionPath = false;
+  if (typeof window !== "undefined") {
+    const currentPath = window.location.pathname;
+    isExceptionPath = (
+      currentPath === "/" ||
+      currentPath === "/login" ||
+      currentPath.startsWith("/login/") ||
+      currentPath === "/signup" ||
+      currentPath.startsWith("/signup/")
+    );
+  }
+
+  if (response.status === 401 && !isRefreshRequest && !isExceptionPath) {
     try {
       console.log("🔄 액세스 토큰 갱신 시도");
-      console.log("요청함");
-      await refreshAccessToken(); // 토큰 재발급
-      response = await request(); // 재요청
+      await refreshAccessToken();
+      response = await request();
     } catch (e) {
       console.error("❌ 액세스 토큰 재발급 실패");
-      logout(); // 세션 만료 처리
+      logout();
       throw new Error("세션이 만료되었습니다. 다시 로그인해주세요.");
     }
   }

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import { getUserApi } from "@/lib/api/user.api";
 import { loginApi, logoutApi, registerApi } from "@/lib/api/auth.api";
+import { usePathname } from "next/navigation";
 
 export type User = {
   id: string;
@@ -30,6 +31,7 @@ export const useAuth = () => {
 
 export default function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
+  const pathname = usePathname();
 
   const getUser = async () => {
     try {
@@ -55,8 +57,10 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
   };
 
   useEffect(() => {
+    // 예외 경로: 홈(랜딩)페이지와 /auth 하위 경로들
+    if (pathname === "/" || pathname.startsWith("/auth")) return;
     getUser();
-  }, []);
+  }, [pathname]);
 
   return <AuthContext.Provider value={{ user, login, logout, register }}>{children}</AuthContext.Provider>;
 }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

> 어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
> 해당 작업을 파악하기 위한 개발 계획 문서, 피그마, QA 문서등의 링크를 첨부해주세요.

### *코드리뷰 신기능 실험을 위해 코파일럿 리뷰어를 추가해 보았습니다. 코파일럿 리뷰는 크게 신경쓰지 않을 예정이며 발견하지 못한 수정사항이나 개선사항이 있을 때만 참고할 예정입니다. @Jam1eL1 님의 코드리뷰를 우선합니다.*

<img width="1921" height="989" alt="image" src="https://github.com/user-attachments/assets/7749289d-ee87-4425-8bc9-d853dc7e9a3e" />

- 랜딩페이지,로그인페이지,회원가입 페이지들에서 리프레쉬토큰만 존재하고 액세스토큰이 없을 시, 액세스토큰을 자동으로 재발급받는 요청을 서버로 보내고있음. 그러나 랜딩페이지와 FE경로상 (auth)하위 url들에 대해서는 액세스토큰을 재발급하지 않도록 예외url들을 설정해야 합니다. (백엔드로 무한 요청 방지)

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?

> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요

- ( /, /login, /login/*, /signup, /signup/* )경로에서 401 에러 발생 시 리프레시 토큰을 통한 액세스토큰 재발급 로직이 실행되지 않도록 예외처리 추가.
- 인증이 필요 없는 페이지에서 불필요한 토큰 재발급을 방지하여 인증 로직을 개선.

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?

> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 적어주세요

- 랜딩페이지와 로그인페이지, 회원가입 페이지들(/, /login, /login/*, /signup, /signup/* )에서 더이상 [리프레쉬토큰O 액세스토큰X]과 같은 상태일때 액세스토큰을 자동으로 재발급하지 않습니다.

## 📌 PR 진행 시 이러한 점들을 참고해 주세요

- Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
- Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
- Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 3일 이내에 진행해 주세요.
- Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
  - P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
  - P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
  - P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
