### PR TITLE
refactor:랜딩페이지, 상품상세페이지 리팩터링[조성빈]

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,12 +2,12 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
-  // eslint: {
-  //   ignoreDuringBuilds: true, // 빌드 시 ESLint 무시
-  // },
-  // typescript: {
-  //   ignoreBuildErrors: true, // TypeScript 오류도 무시하려면
-  // },
+  eslint: {
+    ignoreDuringBuilds: true, // 빌드 시 ESLint 무시
+  },
+  typescript: {
+    ignoreBuildErrors: true, // TypeScript 오류도 무시하려면
+  },
   images: {
     remotePatterns: [{ hostname: "example.com" }, { hostname: "team3-snack-s3.s3.amazonaws.com" }],
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,12 +2,12 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
-  eslint: {
-    ignoreDuringBuilds: true, // 빌드 시 ESLint 무시
-  },
-  typescript: {
-    ignoreBuildErrors: true, // TypeScript 오류도 무시하려면
-  },
+  // eslint: {
+  //   ignoreDuringBuilds: true, // 빌드 시 ESLint 무시
+  // },
+  // typescript: {
+  //   ignoreBuildErrors: true, // TypeScript 오류도 무시하려면
+  // },
   images: {
     remotePatterns: [{ hostname: "example.com" }, { hostname: "team3-snack-s3.s3.amazonaws.com" }],
   },

--- a/src/app/(main)/my/order-list/page.tsx
+++ b/src/app/(main)/my/order-list/page.tsx
@@ -41,14 +41,14 @@ export default function MyOrderListPage() {
     }
   })();
 
-  const getProductName = (orderedItems: TOrderItem["orderedItems"]) => {
-    if (!orderedItems.length) return "상품 없음";
+  const getProductName = (receipts: TOrderItem["receipts"]) => {
+    if (!receipts.length) return "상품 없음";
 
-    if (orderedItems.length === 1) {
-      return orderedItems[0].receipt.productName;
+    if (receipts.length === 1) {
+      return receipts[0].productName;
     }
 
-    return `${orderedItems[0].receipt.productName} 외 ${orderedItems.length - 1}건`;
+    return `${receipts[0].productName} 외 ${receipts.length - 1}건`;
   };
 
   const paginated = sorted.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
@@ -74,7 +74,7 @@ export default function MyOrderListPage() {
             <MyRequestList
               key={item.id}
               requestDate={formatDate(item.createdAt)}
-              productName={getProductName(item.orderedItems)}
+              productName={getProductName(item.receipts)}
               price={item.totalPrice}
               status={convertStatus(item.status)}
               onRequestCancel={() => console.log("취소", item.id)}

--- a/src/app/(main)/products/[productId]/page.tsx
+++ b/src/app/(main)/products/[productId]/page.tsx
@@ -5,6 +5,7 @@ import { useEffect } from "react";
 import ProductDetail from "@/components/common/ProductDetail";
 import { CATEGORIES } from "@/lib/utils/categories.util";
 import SubCategoryItem from "@/components/common/SubCategoryItem";
+import SubCategoryTabs from "@/app/(main)/products/_components/SubCategoryTabs";
 import { useCategoryStore } from "@/stores/categoryStore";
 import { useProductDetail } from "@/hooks/useProductDetail";
 
@@ -22,11 +23,15 @@ export default function ProductDetailPage() {
   }, [product?.category?.id, findCategoryPath]);
 
   if (!productId || isNaN(productId)) {
-    return <div className="px-6 py-10">잘못된 접근입니다.</div>;
+    return <div className="py-10">잘못된 접근입니다.</div>;
   }
 
   return (
-    <div className="w-full flex gap-6 px-6 py-10">
+    <div className="w-full flex flex-col mt-4 sm:flex-row sm:pt-0 gap-6">
+      <div className="block sm:hidden">
+        <SubCategoryTabs />
+      </div>
+
       <div className="hidden sm:block w-[180px] shrink-0">
         <SubCategoryItem categories={CATEGORIES} useExternalState />
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,59 +12,56 @@ const CARD_TEXTS = [
 
 export default function LandingPage() {
   return (
-    <div className="w-full h-[calc(100vh-80px)] flex flex-col bg-white overflow-hidden">
-      <div className="flex-grow" style={{ height: "calc(100vh - 80px - 160px)" }}>
-        <div className="flex flex-col items-center justify-start pt-10 px-4">
-          <h1 className="text-[24px] sm:text-[40px] md:text-5xl font-extrabold text-primary-950 text-center leading-none whitespace-nowrap">
-            내가 원하는 간식을 쉽고 빠르게 구매
-          </h1>
-          <br />
-          <h2 className="text-[20px] sm:text-[24px] md:text-2xl font-semibold text-primary-300 text-center leading-tight">
-            with Snack
-          </h2>
+    <div className="flex flex-col">
+      <div className="flex flex-col items-center justify-start pt-10flex-grow">
+        <h1 className="text-center text-2xl sm:text-4xl md:text-5xl font-extrabold text-primary-950 leading-tight">
+          내가 원하는 간식을 쉽고 빠르게 구매
+        </h1>
 
-          <Link
-            href="/signup"
-            className="mt-6 bg-primary-950 text-white px-5 py-2.5 rounded-full flex items-center gap-1"
-          >
-            <span className="text-base font-bold">Sign Now</span>
-            <ArrowRightIcon />
-          </Link>
+        <h2 className="mt-2 text-center text-lg sm:text-xl md:text-2xl font-semibold text-primary-300">with Snack</h2>
 
-          <div className="mt-10 w-[90%] max-w-[1300px] h-auto rounded-[10px] overflow-hidden">
-            <Image
-              src="/images/landingPage_mobile.png"
-              alt="mobile preview"
-              width={1300}
-              height={600}
-              className="block sm:hidden w-full h-auto"
-            />
+        <Link
+          href="/signup/super-admin"
+          className="mt-6 bg-primary-950 text-white px-5 py-2.5 rounded-full flex items-center gap-1"
+        >
+          <span className="text-base font-bold">Sign Now</span>
+          <ArrowRightIcon />
+        </Link>
 
-            <Image
-              src="/images/landingPage_tablet.png"
-              alt="tablet preview"
-              width={1300}
-              height={600}
-              className="hidden sm:block md:hidden w-full h-auto"
-            />
+        <div className="mt-10 w-full max-w-[1300px] rounded-[10px] overflow-hidden">
+          <Image
+            src="/images/landingPage_mobile.png"
+            alt="mobile preview"
+            width={1300}
+            height={600}
+            className="block sm:hidden w-full h-auto"
+          />
 
-            <Image
-              src="/images/landingPage_desktop.png"
-              alt="desktop preview"
-              width={1300}
-              height={600}
-              className="hidden md:block w-full h-auto"
-            />
-          </div>
+          <Image
+            src="/images/landingPage_tablet.png"
+            alt="tablet preview"
+            width={1300}
+            height={600}
+            className="hidden sm:block md:hidden w-full h-auto"
+          />
+
+          <Image
+            src="/images/landingPage_desktop.png"
+            alt="desktop preview"
+            width={1300}
+            height={600}
+            className="hidden md:block w-full h-auto"
+          />
         </div>
       </div>
 
-      <div className="hidden sm:block h-[160px] w-full overflow-hidden backdrop-blur-[2px] py-6">
+      {/* ✅ Desktop/Tablet 고정 슬라이드 */}
+      <div className="hidden sm:block fixed bottom-0 w-full py-6 overflow-hidden z-20 bg-transparent backdrop-blur">
         <div className="flex animate-slide gap-10 w-max px-8">
-          {[...CARD_TEXTS, ...CARD_TEXTS].map((text, idx) => (
+          {[...CARD_TEXTS, ...CARD_TEXTS, ...CARD_TEXTS].map((text, idx) => (
             <div
               key={idx}
-              className="h-[112px] px-[30px] py-[30px] bg-white/40 rounded-lg shadow-[0px_7px_20px_0px_rgba(0,0,0,0.02)] outline outline-1 outline-offset-[-1px] outline-primary-100 backdrop-blur-[20px] inline-flex justify-center items-center gap-4 w-fit"
+              className="h-[112px] px-[30px] py-[30px] bg-white/20 rounded-lg shadow-[0_7px_20px_rgba(0,0,0,0.02)] outline outline-1 outline-offset-[-1px] outline-primary-100 backdrop-blur-[20px] inline-flex justify-center items-center"
             >
               <div className="text-primary-500 text-base font-medium whitespace-pre-line">{text}</div>
             </div>
@@ -72,32 +69,26 @@ export default function LandingPage() {
         </div>
       </div>
 
-      <div className="block sm:hidden w-full mt-[-80px] mb-[40px] relative z-10">
-        <div className="h-[260px] relative backdrop-blur-[2px]">
-          <div className="absolute top-0 left-0 w-full h-[112px] overflow-hidden">
-            <div className="flex animate-slide gap-6 w-max px-8">
-              {[...CARD_TEXTS, ...CARD_TEXTS].map((text, idx) => (
-                <div
-                  key={`row1-${idx}`}
-                  className="min-w-[250px] h-[112px] px-6 py-4 bg-white/40 rounded-lg shadow-md outline outline-1 outline-offset-[-1px] outline-primary-100 backdrop-blur-[20px] flex items-center justify-center"
-                >
-                  <div className="text-primary-500 text-base font-medium whitespace-pre-line text-center">{text}</div>
-                </div>
-              ))}
+      {/* ✅ Mobile 고정 슬라이드 */}
+      <div className="block sm:hidden fixed bottom-0 w-full z-20 bg-transparent backdrop-blur ">
+        <div className="h-[260px] relative">
+          {[0, 1].map((row) => (
+            <div
+              key={row}
+              className={`absolute left-0 w-full h-[112px] overflow-hidden ${row === 1 ? "top-[130px]" : "top-0"}`}
+            >
+              <div className={`flex ${row % 2 === 0 ? "animate-slide" : "animate-slide-reverse"} gap-6 w-max px-8`}>
+                {[...CARD_TEXTS, ...CARD_TEXTS].map((text, idx) => (
+                  <div
+                    key={`row${row}-${idx}`}
+                    className="min-w-[250px] h-[112px] px-6 py-4 bg-white/40 rounded-lg shadow-md outline outline-1 outline-offset-[-1px] outline-primary-100 backdrop-blur-[20px] flex items-center justify-center"
+                  >
+                    <div className="text-primary-500 text-base font-medium whitespace-pre-line text-center">{text}</div>
+                  </div>
+                ))}
+              </div>
             </div>
-          </div>
-          <div className="absolute top-[116px] left-0 w-full h-[112px] overflow-hidden">
-            <div className="flex animate-slide-reverse gap-6 w-max px-8">
-              {[...CARD_TEXTS, ...CARD_TEXTS].map((text, idx) => (
-                <div
-                  key={`row2-${idx}`}
-                  className="min-w-[250px] h-[112px] px-6 py-4 bg-white/40 rounded-lg shadow-md outline outline-1 outline-offset-[-1px] outline-primary-100 backdrop-blur-[20px] flex items-center justify-center"
-                >
-                  <div className="text-primary-500 text-base font-medium whitespace-pre-line text-center">{text}</div>
-                </div>
-              ))}
-            </div>
-          </div>
+          ))}
         </div>
       </div>
     </div>

--- a/src/components/common/ConfirmationModal.tsx
+++ b/src/components/common/ConfirmationModal.tsx
@@ -1,16 +1,15 @@
-import React, { FC } from "react";
+import React, { FC, useRef } from "react";
+import XIconSvg from "@/components/svg/XIconSvg";
 
 type TConfirmationModalProps = {
-  isOpen: boolean; // 모달을 열고 닫는 상태
-  productName: string; // 삭제할 상품명
-  onCancel: () => void; // 취소 버튼 클릭 시 실행될 함수
-  onDelete: () => void; // 상품 삭제 버튼 클릭 시 실행될 함수
-
-  // 새롭게 추가된 props
-  modalTitle?: string; // 모달 제목 (선택 사항, 기본값 제공)
-  modalDescription?: string; // 모달 설명 (선택 사항, 기본값 제공)
-  confirmButtonText?: string; // 확인/삭제 버튼 텍스트 (선택 사항, 기본값 제공)
-  cancelButtonText?: string; // 취소 버튼 텍스트 (선택 사항, 기본값 제공)
+  isOpen: boolean;
+  productName: string;
+  onCancel: () => void;
+  onDelete: () => void;
+  modalTitle?: string;
+  modalDescription?: string;
+  confirmButtonText?: string;
+  cancelButtonText?: string;
 };
 
 const ConfirmationModal: FC<TConfirmationModalProps> = ({
@@ -18,61 +17,42 @@ const ConfirmationModal: FC<TConfirmationModalProps> = ({
   productName,
   onCancel,
   onDelete,
-  // props에 기본값 할당
   modalTitle = "상품을 삭제하시겠어요?",
   modalDescription = "삭제 후에는 복구할 수 없습니다.",
   confirmButtonText = "상품 삭제",
   cancelButtonText = "더 생각해볼게요",
 }) => {
-  // isOpen이 false이면 모달을 렌더링하지 않음
-  if (!isOpen) {
-    return null;
-  }
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  if (!isOpen) return null;
+
+  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (overlayRef.current && e.target === overlayRef.current) {
+      onCancel();
+    }
+  };
 
   return (
-    // 모달 오버레이 (fixed position, 전체 화면, 반투명 배경)
-    <div className="fixed inset-0 z-50 flex items-center backdrop-blur-xs justify-center font-suit">
-      {/* 모달 내용 컨테이너 */}
+    <div ref={overlayRef} onClick={handleOverlayClick} className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="bg-white rounded-md p-6 w-full max-w-md mx-4 sm:mx-0">
-        {/* Title */}
-        <h2 className="text-lg font-bold text-black text-center mb-2">
-          {modalTitle} {/* props로 받은 제목 사용 */}
-        </h2>
-        {/* Confirmation Message */}
-        <p className="text-primary-900 text-center text-md mb-6">
-          {modalDescription} {/* props로 받은 설명 사용 */}
-        </p>
-        {/* Product to Delete section */}
-        <div className="flex items-center justify-center mb-8">
-          {/* Red X Icon */}
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            className="h-5 w-5 text-white mr-2"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-          >
-            <circle cx="12" cy="12" r="12" fill="#4C8AE1" />
-            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-          </svg>
-          {/* Product Name */}
+        <h2 className="text-lg font-bold text-black text-center mb-2">{modalTitle}</h2>
+        <p className="text-primary-900 text-center text-md mb-6">{modalDescription}</p>
+        <div className="flex items-center justify-center gap-2 mb-8">
+          <XIconSvg stroke="white" className="w-4 h-4" bgColor="red" />
           <span className="text-primary-950 font-bold">{productName}</span>
-          <span className="ml-1 text-red"></span>
         </div>
-        {/* Buttons */}
         <div className="flex flex-col sm:flex-row justify-center space-y-3 sm:space-y-0 sm:space-x-4">
           <button
             onClick={onCancel}
-            className="w-full  py-5 px-10 border border-primary-300  text-sm font-medium text-primary-700 bg-white hover:bg-primary-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-300 transition-colors duration-200"
+            className="w-full py-5 px-10 border border-primary-300 text-sm font-medium text-primary-700 bg-white hover:bg-primary-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-300 transition-colors duration-200 cursor-pointer"
           >
-            {cancelButtonText} {/* props로 받은 취소 버튼 텍스트 사용 */}
+            {cancelButtonText}
           </button>
           <button
             onClick={onDelete}
-            className="w-full  py-5 px-10 border border-transparent  text-sm font-medium text-white bg-primary-900 hover:bg-primary-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-900 transition-colors duration-200"
+            className="w-full py-5 px-10 border border-transparent text-sm font-medium text-white bg-primary-900 hover:bg-primary-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-900 transition-colors duration-200 cursor-pointer"
           >
-            {confirmButtonText} {/* props로 받은 확인/삭제 버튼 텍스트 사용 */}
+            {confirmButtonText}
           </button>
         </div>
       </div>

--- a/src/components/common/ProductDetail.tsx
+++ b/src/components/common/ProductDetail.tsx
@@ -12,6 +12,7 @@ import CartAndLikeButtons from "./ProductDetail/CartAndLikeButtons";
 import ProductInfoSections from "./ProductDetail/ProductInfoSections";
 import { useAuth } from "@/providers/AuthProvider";
 import { useCurrentSubCategory } from "@/hooks/useCurrentSubCategory";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 type ProductDetailProps = {
   productId: number;
@@ -22,8 +23,22 @@ export default function ProductDetail({ productId }: ProductDetailProps) {
   const { data: product, isLoading, isError } = useProductDetail(productId);
   const { user } = useAuth();
   const router = useRouter();
-
   const { findCategoryPath } = useCurrentSubCategory();
+  const queryClient = useQueryClient();
+
+  const { mutate: mutateAddToCart } = useMutation({
+    mutationFn: () => {
+      if (!product) throw new Error("상품 정보가 없습니다.");
+      return addToCart(product.id, selectedQuantity);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["cart"] });
+      router.push("/cart");
+    },
+    onError: () => {
+      alert("장바구니 추가 실패");
+    },
+  });
 
   useEffect(() => {
     if (product?.category?.id) {
@@ -34,24 +49,19 @@ export default function ProductDetail({ productId }: ProductDetailProps) {
   if (isLoading) return <p>로딩 중...</p>;
   if (isError || !product) return <p>상품 정보를 불러올 수 없습니다.</p>;
 
-  const handleAddToCart = async () => {
+  const handleAddToCart = () => {
     if (selectedQuantity < 1) {
       alert("상품의 수량을 1개 이상 선택해주세요.");
       return;
     }
 
-    try {
-      await addToCart(product.id, selectedQuantity);
-      router.push("/cart");
-    } catch (error) {
-      console.error("장바구니 추가 실패:", error);
-    }
+    mutateAddToCart();
   };
 
   const canEdit = user?.id === product.creatorId || user?.role === "ADMIN" || user?.role === "SUPER_ADMIN";
 
   return (
-    <div className="w-full flex flex-col justify-center items-center px-6 sm:px-0 sm:max-w-[1180px]">
+    <div className="w-full flex flex-col justify-center items-center sm:max-w-[1180px]">
       <div className="w-full flex flex-col justify-center items-start gap-7.5">
         <CategoryNavigation
           parentCategory={product.category.parent?.name ?? "기타"}

--- a/src/components/common/ProductDetail/ProductActions.tsx
+++ b/src/components/common/ProductDetail/ProductActions.tsx
@@ -1,9 +1,12 @@
-import { useState } from "react";
+"use client";
+
 import QuantityDropdown from "../QuantityDropdown";
 import MenuDropdown from "../MenuDropdown";
-import ConfirmationModal from "@/components/common/ConfirmationModal"; // 모달 import
-import { deleteProductApi } from "@/lib/api/deleteProduct.api";
+import ConfirmationModal from "@/components/common/ConfirmationModal";
 import { useRouter } from "next/navigation";
+import { useModal } from "@/providers/ModalProvider";
+import { useEffect } from "react";
+import { useDeleteProduct } from "@/hooks/useDeleteProduct";
 
 type TProductActionsProps = {
   selectedQuantity: number;
@@ -20,44 +23,50 @@ export default function ProductActions({
   productId,
   productName,
 }: TProductActionsProps) {
-  const [showModal, setShowModal] = useState(false);
   const router = useRouter();
+  const { openModal, closeModal } = useModal();
 
-  const handleDelete = async () => {
-    try {
-      await deleteProductApi(productId);
-      alert("상품이 삭제되었습니다.");
-      router.push("/products");
-    } catch {
-      alert("상품 삭제 실패");
-    }
+  const { mutate: deleteProduct } = useDeleteProduct();
+
+  const handleDelete = () => {
+    deleteProduct(productId, {
+      onSuccess: () => {
+        alert("상품이 삭제되었습니다.");
+        closeModal();
+        router.push("/products");
+      },
+      onError: () => {
+        alert("상품 삭제 실패");
+      },
+    });
   };
 
-  return (
-    <>
-      <div className="flex items-start gap-3.5 sm:gap-5">
-        <QuantityDropdown value={selectedQuantity} onClick={onQuantityChange} />
-
-        {canEdit && (
-          <MenuDropdown
-            menuType="product"
-            // onEdit={() => console.log("상품 수정")}
-            onDelete={() => setShowModal(true)}
-          />
-        )}
-      </div>
-
-      {/* 삭제 확인 모달 */}
+  const handleOpenConfirmModal = () => {
+    openModal(
       <ConfirmationModal
-        isOpen={showModal}
-        onCancel={() => setShowModal(false)}
+        isOpen={true}
+        onCancel={closeModal}
         onDelete={handleDelete}
         productName={productName}
         modalTitle="상품을 삭제하시겠어요?"
         modalDescription="삭제 후에는 복구할 수 없습니다."
         confirmButtonText="상품 삭제"
         cancelButtonText="더 생각해볼게요"
-      />
-    </>
+      />,
+    );
+  };
+
+  useEffect(() => {
+    if (selectedQuantity === 0) {
+      onQuantityChange(1);
+    }
+  }, [selectedQuantity, onQuantityChange]);
+
+  return (
+    <div className="flex items-center gap-3.5 sm:gap-5">
+      <span className="min-w-[32px] whitespace-nowrap text-sm sm:text-base">수량</span>
+      <QuantityDropdown value={selectedQuantity === 0 ? 1 : selectedQuantity} onClick={onQuantityChange} />
+      {canEdit && <MenuDropdown menuType="product" onDelete={handleOpenConfirmModal} />}
+    </div>
   );
 }

--- a/src/components/common/ProductDetail/ProductBasicInfo.tsx
+++ b/src/components/common/ProductDetail/ProductBasicInfo.tsx
@@ -9,8 +9,19 @@ export default function ProductBasicInfo({ product }: TProps) {
   return (
     <div className="inline-flex flex-col justify-start items-start gap-2">
       <div className="flex flex-col sm:flex-row justify-center items-start gap-2">
-        <div className="text-black text-lg/[22px] font-normal tracking-tight">{product.name}</div>
-        <div className="text-secondary-500 text-sm/[17px] font-bold tracking-tight">29회 구매</div>
+        <div
+          className={`
+      text-black text-lg/[22px] font-normal tracking-tight
+      max-w-full
+      break-words
+      sm:max-w-[280px] sm:truncate sm:whitespace-nowrap sm:overflow-hidden
+    `}
+        >
+          {product.name}
+        </div>
+        <div className="text-secondary-500 min-w-[50px] text-sm/[17px] font-bold tracking-tight">
+          {product.cumulativeSales}회 구매
+        </div>
       </div>
       <div className="text-black text-lg/[22px] font-extrabold tracking-tight">{product.price.toLocaleString()}원</div>
     </div>

--- a/src/hooks/useDeleteProduct.ts
+++ b/src/hooks/useDeleteProduct.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { deleteProductApi, deleteProductAsAdminApi } from "@/lib/api/deleteProduct.api";
+import { useAuth } from "@/providers/AuthProvider";
+
+export const useDeleteProduct = () => {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+
+  return useMutation({
+    mutationFn: (productId: number) => {
+      if (!user) throw new Error("로그인이 필요합니다.");
+
+      const isAdmin = user.role === "ADMIN" || user.role === "SUPER_ADMIN";
+      return isAdmin ? deleteProductAsAdminApi(productId) : deleteProductApi(productId);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["products"] });
+    },
+  });
+};

--- a/src/hooks/useProductDetail.ts
+++ b/src/hooks/useProductDetail.ts
@@ -2,10 +2,10 @@ import { useQuery } from "@tanstack/react-query";
 import { getProductById } from "@/lib/api/productDetail.api";
 import type { Product } from "@/types/productDetail.types";
 
-export function useProductDetail(productId: number) {
+export const useProductDetail = (productId: number) => {
   return useQuery<Product>({
     queryKey: ["product", productId],
     queryFn: () => getProductById(productId),
     enabled: !!productId, // productId 있을 때만 실행
   });
-}
+};

--- a/src/lib/api/deleteProduct.api.ts
+++ b/src/lib/api/deleteProduct.api.ts
@@ -1,7 +1,15 @@
 import { cookieFetch } from "./fetchClient.api";
 
+// 일반 유저 삭제
 export const deleteProductApi = async (productId: number): Promise<void> => {
   return await cookieFetch(`/products/${productId}`, {
+    method: "DELETE",
+  });
+};
+
+// 관리자 삭제
+export const deleteProductAsAdminApi = async (productId: number): Promise<void> => {
+  return await cookieFetch(`/admin/products/${productId}`, {
     method: "DELETE",
   });
 };

--- a/src/types/myOrderList.types.ts
+++ b/src/types/myOrderList.types.ts
@@ -4,12 +4,10 @@ export type TOrderItem = {
   totalPrice: number;
   createdAt: string;
   status: "PENDING" | "APPROVED" | "REJECTED";
-  orderedItems: {
-    receipt: {
-      productName: string;
-      price: number;
-      imageUrl: string;
-      quantity: number;
-    };
+  receipts: {
+    productName: string;
+    price: number;
+    imageUrl: string;
+    quantity: number;
   }[];
 };

--- a/src/types/productDetail.types.ts
+++ b/src/types/productDetail.types.ts
@@ -3,6 +3,7 @@ export type Product = {
   name: string;
   price: number;
   imageUrl: string;
+  cumulativeSales: number;
   category: {
     id: number;
     name: string;


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

- 상품상세 페이지에서 장바구니에 상품 추가 혹은 상품리스트에서 상품 삭제시 실시간 갱신되지 않던 오류
- 랜딩 페이지에서 무한 카드 슬라이드 모바일 환경에서 간격 수정 
- sign now 버튼 눌렀을때 존재하지 않는 페이지로 이동하는 오류
- 상품 상세 페이지 상품 삭제 모달 디자인
- 상품 상세페이지 각 버튼에 커서 포인터 
- 상품 상세페이지 quantity dropdown 기본값
- 상품삭제 api 연동 문제 
- 모바일 환경에서 상품상세 페이지 상단에 카테고리 노출되지 않던 문제
- 각 환경에서 불필요한 패딩
- 시안과 다르던 상품상세페이지 드롭다운 앞에 "수량" 텍스트" 추가
- 구매횟수 연동이 되어있지않던 문제

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?

- 상품 상세 페이지에서 장바구니 추가 시 실시간 갱신되지 않던 문제 수정
→ 장바구니 상태를 전역 상태(Zustand) 또는 react-query invalidate 방식으로 처리하여 즉시 반영되도록 개선

상품 리스트에서 상품 삭제 시 실시간 반영되지 않던 문제 해결
→ 삭제 후 react-query 캐시 갱신 (invalidateQueries) 처리

상품 삭제 모달 디자인 적용
→ 피그마 시안 기반으로 삭제 경고 메시지 및 버튼 스타일 반영

상품 상세 페이지 수량 드롭다운 앞에 "수량" 텍스트 추가
→ UI 일관성을 위해 명시적 라벨 표시

각 버튼 커서 포인터 적용
→ 클릭 가능한 UI 요소에 cursor: pointer 추가로 UX 개선

QuantityDropdown 기본값 문제 수정
→ selectedQuantity === 0일 때 자동으로 1로 설정

모바일 환경에서 무한 카드 슬라이드 간격 이슈 수정
→ Tailwind gap 조정으로 레이아웃 어긋남 문제 해결

Sign Now 버튼 클릭 시 존재하지 않는 경로로 이동하던 문제 수정
→ 링크 경로를 /signup/super-admin으로 정상 연결

상품 삭제 API 연동 문제 해결
→ 유저의 role을 기반으로 API 경로 분기 (/products/:id vs /admin/products/:id)

구매횟수(cumulativeSales) 미연동 문제 수정
→ 구매 요청 완료 시 해당 상품의 cumulativeSales 값 증가 로직 연동 완료

모바일 환경에서 상품 상세 페이지 상단 카테고리 드롭다운 노출 문제 해결
→ Zustand 전역 상태(currentSubCategory) 활용해 정상 노출

불필요한 패딩 제거
→ 각 뷰포트(Device size)별 여백(padding) 최적화하여 시안과 맞춤

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?


## 📌 PR 진행 시 이러한 점들을 참고해 주세요

- Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
- Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
- Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 3일 이내에 진행해 주세요.
- Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
  - P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
  - P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
  - P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
