### PR TITLE
QA: httpOnly 쿠키 기반 자동 토큰 재발급 로직 및 인증 상태 확인 개선

### DIFF
--- a/src/lib/api/fetchClient.api.ts
+++ b/src/lib/api/fetchClient.api.ts
@@ -33,10 +33,11 @@ export const cookieFetch = async <T>(path: string, options: RequestInit = {}): P
     try {
       console.log("🔄 액세스 토큰 갱신 시도");
       await refreshAccessToken();
+      console.log("✅ 액세스 토큰 갱신 성공, 원본 요청 재시도");
       response = await request();
-    } catch {
-      console.error("❌ 액세스 토큰 재발급 실패");
-      logout();
+    } catch (refreshError) {
+      console.error("❌ 액세스 토큰 재발급 실패:", refreshError);
+      await logout();
       throw new Error("세션이 만료되었습니다. 다시 로그인해주세요.");
     }
   }

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -25,7 +25,8 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
     try {
       const userData = await getUserApi();
       setUser(userData);
-    } catch {
+    } catch (error) {
+      console.log("유저 정보 조회 실패:", error);
       setUser(null);
     }
   };
@@ -48,8 +49,21 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
   useEffect(() => {
     // 예외 경로: 홈(랜딩)페이지와 /auth 하위 경로들
     if (pathname === "/" || pathname.startsWith("/auth") || pathname.startsWith("/login") || pathname.startsWith("/signup")) return;
+
+    console.log("🔍 인증 상태 확인:", pathname);
     getUser();
   }, [pathname]);
+
+  // 앱 초기 로드시에도 인증 상태 확인
+  useEffect(() => {
+    // 예외 경로가 아닌 경우에만 초기 인증 상태 확인
+    const currentPath = pathname;
+    if (currentPath !== "/" && !currentPath.startsWith("/auth") && !currentPath.startsWith("/login") && !currentPath.startsWith("/signup")) {
+      console.log("🚀 앱 초기 로드: 인증 상태 확인 시작");
+      getUser();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // 한 번만 실행
 
   return <AuthContext.Provider value={{ user, login, logout, register }}>{children}</AuthContext.Provider>;
 }


### PR DESCRIPTION
# ⚙️해당 이슈: https://github.com/De-cal/6-Snack-bE/issues/114

## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

> 어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
> 해당 작업을 파악하기 위한 개발 계획 문서, 피그마, QA 문서등의 링크를 첨부해주세요.

- 액세스토큰 없이 리프레쉬 토큰만 존재할시 토큰 재발급을수행하지 않아 로그인 페이지로 튕겨나는 문제

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?

> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요

- 인증이 필요한 경로 진입 시 항상 유저 정보 API 호출로 인증 상태 확인
- 401 발생 시 리프레시 토큰으로 액세스 토큰 자동 재발급 및 재시도 로직 강화
- 인증 실패 시 로그아웃 및 로그인 페이지 이동 처리 명확화
- 디버깅 및 유지보수를 위한 상세 로그 추가

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?

> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 적어주세요

<img width="141" height="84" alt="image" src="https://github.com/user-attachments/assets/6b97e389-e396-4ace-84f2-f9a8d04aaf66" />

- 로그인 하여 액세스토큰,리프레쉬토큰을 발급받은 상태에서 액세스토큰을 지우고 페이지를 이동하면, 액세스토큰이 재발급되며 로그인페이지로 튕겨나지 않고 페이지 탐색 및 이용 가능합니다

## 📌 PR 진행 시 이러한 점들을 참고해 주세요

- Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
- Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
- Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 3일 이내에 진행해 주세요.
- Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
  - P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
  - P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
  - P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
