### PR TITLE
feat:상품상세페이지에 찜하기 기능을 추가하였습니다 [조성빈]

### DIFF
--- a/src/components/common/ProductDetail/CartAndLikeButtons.tsx
+++ b/src/components/common/ProductDetail/CartAndLikeButtons.tsx
@@ -1,23 +1,22 @@
 import React from "react";
 import Button from "../../ui/Button";
+import LikeIconSvg from "@/components/svg/LikeIconSvg";
 
 type TCartAndLikeButtonsProps = {
   onAddToCart: () => void;
-  // productId?: number;
-  // selectedQuantity?: number;
+  isFavorite: boolean;
+  productId: number;
+  onToggleFavorite: (isFavoriteNow: boolean) => void;
 };
 
-export default function CartAndLikeButtons({ onAddToCart }: TCartAndLikeButtonsProps) {
+export default function CartAndLikeButtons({ onAddToCart, isFavorite, onToggleFavorite }: TCartAndLikeButtonsProps) {
   return (
     <div className="flex gap-4 w-full">
       <Button type="primary" label="장바구니 담기" className="w-full h-16 font-bold" onClick={onAddToCart} />
 
-      {/* 좋아요 버튼은 이후 추가 예정 */}
-      {/* 
       <div className="w-16 h-16 border rounded flex items-center justify-center">
-        <Image src={ic_like_normal} alt="좋아요" width={24} height={24} />
-      </div> 
-      */}
+        <LikeIconSvg isLiked={isFavorite} onToggle={onToggleFavorite} />
+      </div>
     </div>
   );
 }

--- a/src/components/layout/AuthenticatedHeader.tsx
+++ b/src/components/layout/AuthenticatedHeader.tsx
@@ -164,7 +164,7 @@ export default function AuthenticatedHeader() {
         <div className="hidden md:block">
           <Link href="/my/favorites">
             <div className="flex items-center justify-center p-1 gap-0.5">
-              <LikeIconSvg className="pointer-events-none" />
+              <LikeIconSvg isLiked={false} className="pointer-events-none" />
               <p
                 className={`text-primary-950 text-sm/[17px] tracking-tight ${pathname === "/my/favorites" ? "font-bold" : "font-normal"}`}
               >

--- a/src/components/svg/LikeIconSvg.tsx
+++ b/src/components/svg/LikeIconSvg.tsx
@@ -1,18 +1,14 @@
-import React, { useState } from "react";
+import React from "react";
 
 type TLikeIconSvgProps = {
   className?: string;
-  initialLiked?: boolean;
-  onToggle?: (isLiked: boolean) => void;
+  isLiked: boolean; // ✅ 상태를 직접 props로 받는다
+  onToggle?: (isLikedNow: boolean) => void;
 };
 
-export default function LikeIconSvg({ className = "", initialLiked = false, onToggle }: TLikeIconSvgProps) {
-  const [isLiked, setIsLiked] = useState(initialLiked);
-
+export default function LikeIconSvg({ className = "", isLiked, onToggle }: TLikeIconSvgProps) {
   const handleClick = () => {
-    const newLikedState = !isLiked;
-    setIsLiked(newLikedState);
-    onToggle?.(newLikedState);
+    onToggle?.(isLiked); // 현재 상태 전달
   };
 
   return (
@@ -26,13 +22,11 @@ export default function LikeIconSvg({ className = "", initialLiked = false, onTo
       onClick={handleClick}
     >
       {isLiked ? (
-        // 좋아요 눌린 상태 (빨간 하트)
         <path
           d="M3.70857 5.08224C5.98667 2.83537 9.68022 2.83531 11.9583 5.08224C11.9721 5.09588 11.9849 5.1105 11.9986 5.12424L12.0003 5.12254C12.0139 5.1088 12.0279 5.09531 12.0417 5.08167C14.3198 2.83473 18.0133 2.83478 20.2914 5.08167C22.5695 7.32863 22.5695 10.9717 20.2914 13.2186C20.2776 13.2323 20.2628 13.2449 20.2488 13.2584L20.25 13.2595L12.0003 21.3965L3.75058 13.2595C3.73664 13.246 3.7224 13.2329 3.70857 13.2192C1.43048 10.9722 1.43048 7.3292 3.70857 5.08224Z"
           fill="#E9655E"
         />
       ) : (
-        // 좋아요 안 눌린 상태 (빈 하트)
         <path
           d="M12.0417 5.08214C14.3198 2.83522 18.0126 2.83528 20.2907 5.08214C22.5688 7.32911 22.5688 10.9719 20.2907 13.2189C20.277 13.2324 20.2626 13.2455 20.2487 13.2589L20.2497 13.2599L11.9997 21.3966L3.7507 13.2599L3.7087 13.2189C1.50177 11.0421 1.43256 7.55561 3.50167 5.29699L3.7087 5.08214C5.98675 2.83567 9.67975 2.83555 11.9577 5.08214C11.9716 5.09579 11.9851 5.11039 11.9987 5.12414L11.9997 5.12218L12.0417 5.08214ZM19.238 6.14953C17.5968 4.53087 14.9598 4.48059 13.2566 5.99816L13.0944 6.14953L13.0515 6.1925L11.988 7.24132L10.9343 6.18175C10.9201 6.16744 10.9082 6.15511 10.9001 6.1466C10.8981 6.14443 10.8962 6.14182 10.8942 6.13976C9.25257 4.5314 6.62326 4.48418 4.92355 5.99816L4.76144 6.1505C3.07912 7.81006 3.07901 10.492 4.76144 12.1515L4.76241 12.1525C4.76386 12.1538 4.77023 12.1595 4.77413 12.1632L4.79269 12.1818L4.79855 12.1866L4.80343 12.1915L11.9997 19.2892L18.113 13.2589L18.1013 13.2482L19.2058 12.1798L19.2419 12.1466C20.8677 10.5387 20.917 7.97494 19.3903 6.30871L19.238 6.14953Z"
           fill="currentColor"

--- a/src/hooks/useToggleFavorite.ts
+++ b/src/hooks/useToggleFavorite.ts
@@ -27,7 +27,7 @@ export const useToggleFavorite = (
       await queryClient.cancelQueries({ queryKey: ["productDetail", productId] });
 
       const prev = queryClient.getQueryData(["productDetail", productId]);
-      queryClient.setQueryData(["productDetail", productId], (old: any) => {
+      queryClient.setQueryData<{ isFavorite: boolean }>(["productDetail", productId], (old) => {
         if (!old) return old;
         return { ...old, isFavorite: !isFavoriteNow };
       });

--- a/src/hooks/useToggleFavorite.ts
+++ b/src/hooks/useToggleFavorite.ts
@@ -1,0 +1,48 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createFavorite, deleteFavorite } from "@/lib/api/favorite.api";
+
+export const useToggleFavorite = (
+  productId: number,
+  {
+    onMutate,
+    onError,
+  }: {
+    onMutate?: () => void;
+    onError?: () => void;
+  } = {},
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (isFavoriteNow: boolean) => {
+      if (isFavoriteNow) {
+        await deleteFavorite(productId.toString());
+      } else {
+        await createFavorite(productId.toString());
+      }
+    },
+    onMutate: async (isFavoriteNow) => {
+      onMutate?.();
+
+      await queryClient.cancelQueries({ queryKey: ["productDetail", productId] });
+
+      const prev = queryClient.getQueryData(["productDetail", productId]);
+      queryClient.setQueryData(["productDetail", productId], (old: any) => {
+        if (!old) return old;
+        return { ...old, isFavorite: !isFavoriteNow };
+      });
+
+      return { prev };
+    },
+    onError: (_err, _variables, context) => {
+      onError?.();
+      if (context?.prev) {
+        queryClient.setQueryData(["productDetail", productId], context.prev);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["productDetail", productId] });
+      queryClient.invalidateQueries({ queryKey: ["favorites"] });
+    },
+  });
+};

--- a/src/types/productDetail.types.ts
+++ b/src/types/productDetail.types.ts
@@ -13,4 +13,6 @@ export type TProduct = {
     };
   };
   creatorId: string;
+
+  isFavorite: boolean;
 };


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

- 기존 상품 상세 페이지에서 사용자 개인의 찜 상태(좋아요 여부)를 표시하거나 토글하는 기능의 부재
- 이에 따라 사용자가 관심 있는 상품을 저장하거나 취소하는 기능을 추가하여 사용자 경험을 개선

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?

- useToggleFavorite 커스텀 훅 구현
→ POST /favorites/:productId, DELETE /favorites/:productId API를 활용하여 낙관적 업데이트 방식으로 찜 토글 처리

- ProductDetail 컴포넌트에서 isFavorite 상태를 분리 관리하고 useToggleFavorite과 연결

- 하위 컴포넌트(CartAndLikeButtons, LikeIconSvg)에서 props로 상태 및 핸들러 전달

- React Hook 순서 오류 및 찜 상태 UI 지연 문제 해결

- 찜 상태에 따라 하트 색상 실시간 렌더링 처리

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?

- 상품 상세 페이지 진입 시, 기존 찜 상태가 정확히 반영되는지 확인

- 찜하기 하트 클릭 시 서버와 UI가 동기화되는지 확인

- 네트워크 실패 시에도 UI가 롤백되어 일관된 상태를 유지하는지 확인

- 장바구니 담기, 수정/삭제 버튼 등 기존 기능과의 충돌 여부

## 📌 PR 진행 시 이러한 점들을 참고해 주세요

- Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
- Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
- Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 3일 이내에 진행해 주세요.
- Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
  - P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
  - P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
  - P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
