### PR TITLE
fix: 모의발표 핫픽스 "관리자-구매내역확인" 페이지 UI 이슈 개선 [김홍섭]

### DIFF
--- a/src/app/(main)/order-history/page.tsx
+++ b/src/app/(main)/order-history/page.tsx
@@ -271,36 +271,34 @@ const OrderHistoryPage = () => {
             </div>
           )}
         </section>
-        <nav className="self-stretch h-10 inline-flex justify-between items-center px-4" aria-label="페이지 이동">
+        <nav className="self-stretch h-10 flex justify-between items-center px-4" aria-label="페이지 이동">
           {/* Mobile Pagination */}
-          <div className="self-stretch h-10 inline-flex justify-between items-center">
-            <div className="text-center justify-start text-neutral-800 text-base font-normal font-['SUIT']">
-              {currentPage} of {totalPages}
-            </div>
-            <div className="flex justify-start items-center gap-7">
-              <button
-                onClick={() => handlePageChange(currentPage - 1)}
-                disabled={currentPage === 1}
-                className="flex justify-start items-center gap-1.5 cursor-pointer disabled:cursor-not-allowed"
-              >
-                <div className="w-6 h-6 relative overflow-hidden">
-                  <Image src={ChevronLeftIcon} alt="Chevron Left" width={24} height={24} />
-                </div>
-                <div className="text-center justify-start text-zinc-500 text-base font-normal font-['SUIT']">Prev</div>
-              </button>
-              <button
-                onClick={() => handlePageChange(currentPage + 1)}
-                disabled={currentPage === totalPages}
-                className="flex justify-start items-center gap-[5px] cursor-pointer disabled:cursor-not-allowed"
-              >
-                <div className="text-center justify-start text-neutral-800 text-base font-normal font-['SUIT']">
-                  Next
-                </div>
-                <div className="w-6 h-6 relative overflow-hidden">
-                  <Image src={ChevronRightIcon} alt="Chevron Right" width={24} height={24} />
-                </div>
-              </button>
-            </div>
+          <div className="text-neutral-800 text-base font-normal font-['SUIT']">
+            {currentPage} of {totalPages}
+          </div>
+          <div className="flex items-center gap-7">
+            <button
+              onClick={() => handlePageChange(currentPage - 1)}
+              disabled={currentPage === 1}
+              className="flex items-center gap-1.5 cursor-pointer disabled:cursor-not-allowed"
+            >
+              <div className="w-6 h-6 relative overflow-hidden">
+                <Image src={ChevronLeftIcon} alt="Chevron Left" width={24} height={24} />
+              </div>
+              <div className="text-zinc-500 text-base font-normal font-['SUIT']">Prev</div>
+            </button>
+            <button
+              onClick={() => handlePageChange(currentPage + 1)}
+              disabled={currentPage === totalPages}
+              className="flex items-center gap-[5px] cursor-pointer disabled:cursor-not-allowed"
+            >
+              <div className="text-neutral-800 text-base font-normal font-['SUIT']">
+                Next
+              </div>
+              <div className="w-6 h-6 relative overflow-hidden">
+                <Image src={ChevronRightIcon} alt="Chevron Right" width={24} height={24} />
+              </div>
+            </button>
           </div>
         </nav>
       </main>
@@ -509,36 +507,34 @@ const OrderHistoryPage = () => {
             </div>
           )}
         </section>
-        <nav className="self-stretch h-10 inline-flex justify-between items-center px-8" aria-label="페이지 이동">
+        <nav className="self-stretch h-10 flex justify-between items-center px-8" aria-label="페이지 이동">
           {/* Tablet Pagination */}
-          <div className="self-stretch h-10 inline-flex justify-between items-center">
-            <div className="text-center justify-start text-neutral-800 text-base font-normal font-['SUIT']">
-              {currentPage} of {totalPages}
-            </div>
-            <div className="flex justify-start items-center gap-7">
-              <button
-                onClick={() => handlePageChange(currentPage - 1)}
-                disabled={currentPage === 1}
-                className="flex justify-start items-center gap-1.5 cursor-pointer disabled:cursor-not-allowed"
-              >
-                <div className="w-6 h-6 relative overflow-hidden">
-                  <Image src={ChevronLeftIcon} alt="Chevron Left" width={24} height={24} />
-                </div>
-                <div className="text-center justify-start text-zinc-500 text-base font-normal font-['SUIT']">Prev</div>
-              </button>
-              <button
-                onClick={() => handlePageChange(currentPage + 1)}
-                disabled={currentPage === totalPages}
-                className="flex justify-start items-center gap-[5px] cursor-pointer disabled:cursor-not-allowed"
-              >
-                <div className="text-center justify-start text-neutral-800 text-base font-normal font-['SUIT']">
-                  Next
-                </div>
-                <div className="w-6 h-6 relative overflow-hidden">
-                  <Image src={ChevronRightIcon} alt="Chevron Right" width={24} height={24} />
-                </div>
-              </button>
-            </div>
+          <div className="text-neutral-800 text-base font-normal font-['SUIT']">
+            {currentPage} of {totalPages}
+          </div>
+          <div className="flex items-center gap-7">
+            <button
+              onClick={() => handlePageChange(currentPage - 1)}
+              disabled={currentPage === 1}
+              className="flex items-center gap-1.5 cursor-pointer disabled:cursor-not-allowed"
+            >
+              <div className="w-6 h-6 relative overflow-hidden">
+                <Image src={ChevronLeftIcon} alt="Chevron Left" width={24} height={24} />
+              </div>
+              <div className="text-zinc-500 text-base font-normal font-['SUIT']">Prev</div>
+            </button>
+            <button
+              onClick={() => handlePageChange(currentPage + 1)}
+              disabled={currentPage === totalPages}
+              className="flex items-center gap-[5px] cursor-pointer disabled:cursor-not-allowed"
+            >
+              <div className="text-neutral-800 text-base font-normal font-['SUIT']">
+                Next
+              </div>
+              <div className="w-6 h-6 relative overflow-hidden">
+                <Image src={ChevronRightIcon} alt="Chevron Right" width={24} height={24} />
+              </div>
+            </button>
           </div>
         </nav>
       </main>
@@ -652,7 +648,7 @@ const OrderHistoryPage = () => {
             </div>
           </div>
         </section>
-        <section className="w-full flex flex-col gap-2 px-10" aria-labelledby="purchase-list-desktop" role="list">
+        <section className="w-full flex flex-col gap-2 px-10 pb-5" aria-labelledby="purchase-list-desktop" role="list">
           <h2 id="purchase-list-desktop" className="sr-only">구매 내역 목록</h2>
           {/* Desktop Purchase List - Table Format */}
           <div className="self-stretch flex flex-col justify-start items-start">
@@ -722,36 +718,36 @@ const OrderHistoryPage = () => {
             </div>
           </div>
         </section>
-        <nav className="self-stretch h-10 inline-flex justify-between items-center px-10" aria-label="페이지 이동">
+        <nav className="self-stretch h-10 flex justify-between items-center px-10" aria-label="페이지 이동">
           {/* Desktop Pagination */}
-          <div className="self-stretch h-10 inline-flex justify-between items-center">
+          <div className="flex items-center">
             <div className="text-center justify-start text-neutral-800 text-base font-normal font-['SUIT']">
               {currentPage} of {totalPages}
             </div>
-            <div className="flex justify-start items-center gap-7">
-              <button
-                onClick={() => handlePageChange(currentPage - 1)}
-                disabled={currentPage === 1}
-                className="flex justify-start items-center gap-1.5 cursor-pointer disabled:cursor-not-allowed"
-              >
-                <div className="w-6 h-6 relative overflow-hidden">
-                  <Image src={ChevronLeftIcon} alt="Chevron Left" width={24} height={24} />
-                </div>
-                <div className="text-center justify-start text-zinc-500 text-base font-normal font-['SUIT']">Prev</div>
-              </button>
-              <button
-                onClick={() => handlePageChange(currentPage + 1)}
-                disabled={currentPage === totalPages}
-                className="flex justify-start items-center gap-[5px] cursor-pointer disabled:cursor-not-allowed"
-              >
-                <div className="text-center justify-start text-neutral-800 text-base font-normal font-['SUIT']">
-                  Next
-                </div>
-                <div className="w-6 h-6 relative overflow-hidden">
-                  <Image src={ChevronRightIcon} alt="Chevron Right" width={24} height={24} />
-                </div>
-              </button>
-            </div>
+          </div>
+          <div className="flex items-center gap-7">
+            <button
+              onClick={() => handlePageChange(currentPage - 1)}
+              disabled={currentPage === 1}
+              className="flex justify-start items-center gap-1.5 cursor-pointer disabled:cursor-not-allowed"
+            >
+              <div className="w-6 h-6 relative overflow-hidden">
+                <Image src={ChevronLeftIcon} alt="Chevron Left" width={24} height={24} />
+              </div>
+              <div className="text-center justify-start text-zinc-500 text-base font-normal font-['SUIT']">Prev</div>
+            </button>
+            <button
+              onClick={() => handlePageChange(currentPage + 1)}
+              disabled={currentPage === totalPages}
+              className="flex justify-start items-center gap-[5px] cursor-pointer disabled:cursor-not-allowed"
+            >
+              <div className="text-center justify-start text-neutral-800 text-base font-normal font-['SUIT']">
+                Next
+              </div>
+              <div className="w-6 h-6 relative overflow-hidden">
+                <Image src={ChevronRightIcon} alt="Chevron Right" width={24} height={24} />
+              </div>
+            </button>
           </div>
         </nav>
       </main>

--- a/src/app/(main)/order-history/page.tsx
+++ b/src/app/(main)/order-history/page.tsx
@@ -225,7 +225,7 @@ const OrderHistoryPage = () => {
                       </div>
                       {item.adminMessage?.includes("즉시 구매") && (
                         <div className="px-1 py-1 bg-blue-50 rounded-[100px] flex justify-center items-center gap-1">
-                          <div className="justify-center text-blue-500 text-xs font-bold font-['SUIT']">즉시 요청</div>
+                          <div className="justify-center text-blue-500 text-xs font-bold font-['SUIT']">즉시 구매</div>
                         </div>
                       )}
                     </div>
@@ -460,7 +460,7 @@ const OrderHistoryPage = () => {
                           {item.adminMessage?.includes("즉시 구매") && (
                             <div className="px-1 py-1 bg-blue-50 rounded-[100px] flex justify-center items-center gap-1">
                               <div className="justify-center text-blue-500 text-xs font-bold font-['SUIT']">
-                                즉시 요청
+                                즉시 구매
                               </div>
                             </div>
                           )}
@@ -684,7 +684,7 @@ const OrderHistoryPage = () => {
                       {item.adminMessage?.includes("즉시 구매") && (
                         <div className="px-2 py-1 bg-blue-50 rounded-[100px] flex justify-center items-center gap-1 whitespace-nowrap">
                           <div className="justify-center items-center text-center text-blue-500 text-xs font-bold font-['SUIT'] w-12 whitespace-nowrap overflow-hidden text-ellipsis">
-                            즉시 요청
+                            즉시 구매
                           </div>
                         </div>
                       )}

--- a/src/app/(main)/order-history/page.tsx
+++ b/src/app/(main)/order-history/page.tsx
@@ -41,9 +41,9 @@ const OrderHistoryPage = () => {
     <>
       {/* Mobile Layout */}
       <main className="min-h-screen w-full max-w-sm mx-auto relative bg-white overflow-hidden sm:hidden" aria-label="구매 내역 모바일 화면">
-        <header className="self-stretch inline-flex justify-between items-center px-4 pt-4" role="banner">
-          <h1 className="text-neutral-800 text-lg font-bold font-['SUIT']">구매 내역 확인</h1>
-          <nav aria-label="정렬 옵션">
+        <header className="self-stretch flex justify-between items-center px-4 pt-4" role="banner">
+          <h1 className="text-neutral-800 text-lg font-bold font-['SUIT'] flex-shrink-0">구매 내역 확인</h1>
+          <nav aria-label="정렬 옵션" className="flex-shrink-0">
             <div className="relative custom-sort-dropdown w-auto" role="region">
               <Dropdown
                 options={["최신순", "낮은 가격순", "높은 가격순"]}
@@ -225,7 +225,7 @@ const OrderHistoryPage = () => {
                       </div>
                       {item.adminMessage?.includes("즉시 구매") && (
                         <div className="px-1 py-1 bg-blue-50 rounded-[100px] flex justify-center items-center gap-1">
-                          <div className="justify-center text-blue-500 text-xs font-bold font-['SUIT']">즉시 구매</div>
+                          <div className="justify-center text-blue-500 text-xs font-bold font-['SUIT']">즉시 요청</div>
                         </div>
                       )}
                     </div>
@@ -307,9 +307,9 @@ const OrderHistoryPage = () => {
 
       {/* Tablet Layout */}
       <main className="min-h-screen w-full max-w-3xl mx-auto relative bg-white overflow-hidden hidden sm:block md:hidden" aria-label="구매 내역 태블릿 화면">
-        <header className="self-stretch inline-flex justify-between items-center pt-8 px-8" role="banner">
-          <h1 className="text-neutral-800 text-lg font-bold font-['SUIT']">구매 내역 확인</h1>
-          <nav aria-label="정렬 옵션">
+        <header className="self-stretch flex justify-between items-center pt-8 px-8" role="banner">
+          <h1 className="text-neutral-800 text-lg font-bold font-['SUIT'] flex-shrink-0">구매 내역 확인</h1>
+          <nav aria-label="정렬 옵션" className="flex-shrink-0">
             <div className="relative custom-sort-dropdown w-auto" role="region">
               <Dropdown
                 options={["최신순", "낮은 가격순", "높은 가격순"]}
@@ -460,7 +460,7 @@ const OrderHistoryPage = () => {
                           {item.adminMessage?.includes("즉시 구매") && (
                             <div className="px-1 py-1 bg-blue-50 rounded-[100px] flex justify-center items-center gap-1">
                               <div className="justify-center text-blue-500 text-xs font-bold font-['SUIT']">
-                                즉시 구매
+                                즉시 요청
                               </div>
                             </div>
                           )}
@@ -545,9 +545,9 @@ const OrderHistoryPage = () => {
 
       {/* Desktop Layout */}
       <main className="min-h-screen w-full relative bg-white overflow-hidden hidden md:block" aria-label="구매 내역 데스크탑 화면">
-        <header className="self-stretch inline-flex justify-between items-center pt-10 px-10" role="banner">
-          <h1 className="text-neutral-800 text-lg font-bold font-['SUIT']">구매 내역 확인</h1>
-          <nav aria-label="정렬 옵션">
+        <header className="self-stretch flex justify-between items-center pt-10 px-10" role="banner">
+          <h1 className="text-neutral-800 text-lg font-bold font-['SUIT'] flex-shrink-0">구매 내역 확인</h1>
+          <nav aria-label="정렬 옵션" className="flex-shrink-0">
             <div className="relative custom-sort-dropdown w-auto" role="region">
               <Dropdown
                 options={["최신순", "낮은 가격순", "높은 가격순"]}
@@ -684,7 +684,7 @@ const OrderHistoryPage = () => {
                       {item.adminMessage?.includes("즉시 구매") && (
                         <div className="px-2 py-1 bg-blue-50 rounded-[100px] flex justify-center items-center gap-1 whitespace-nowrap">
                           <div className="justify-center items-center text-center text-blue-500 text-xs font-bold font-['SUIT'] w-12 whitespace-nowrap overflow-hidden text-ellipsis">
-                            즉시 구매
+                            즉시 요청
                           </div>
                         </div>
                       )}

--- a/src/hooks/useBudgets.ts
+++ b/src/hooks/useBudgets.ts
@@ -9,6 +9,5 @@ export const useBudgets = () => {
   return useQuery({
     queryKey: ['budgets', companyId],
     queryFn: () => getBudgets(),
-    staleTime: 1000 * 60,
   });
 };

--- a/src/hooks/useBudgets.ts
+++ b/src/hooks/useBudgets.ts
@@ -1,10 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
 import { getBudgets } from '@/lib/api/budgets.api';
+import { useAuth } from '@/providers/AuthProvider';
 
 export const useBudgets = () => {
+  const { user } = useAuth();
+  const companyId = user?.company?.id;
+
   return useQuery({
-    queryKey: ['budgets'],
-    queryFn: getBudgets,
-    staleTime: 1000 * 60, // 1분 캐싱
+    queryKey: ['budgets', companyId],
+    queryFn: () => getBudgets(),
+    staleTime: 1000 * 60,
   });
 };


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

> 어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
> 해당 작업을 파악하기 위한 개발 계획 문서, 피그마, QA 문서등의 링크를 첨부해주세요.

- [ ]  구매 내역 확인 페이지: 이번 달 지출액 (progress bar호버시 아무것도 안뜸)
- [ ]  구매 내역 확인 페이지: 정렬 드롭다운 ui 및 gap / 예산 카드와 리스트 사이, 페이지네이션 사이 gap 추가
- [ ]  구매 내역 확인 페이지에서 총 수량 4개로 fix 되어있습니다. 수정 필요합니다. 텍스트도 ‘총수량’ → ‘총 수량’으로 변경

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?

> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요

- 구매내역확인 페이지에 대한 핫픽스 사항들을 점검하고 개선했습니다

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?

> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 적어주세요

- 로그인 이후 /order-history 경로에서 확인 가능

## 📌 PR 진행 시 이러한 점들을 참고해 주세요

- Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
- Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
- Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 3일 이내에 진행해 주세요.
- Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
  - P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
  - P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
  - P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
