### PR TITLE
fix: 미들웨어에서 accessToken 대신 refreshToken 여부를 판단하여 인증상태 참조하도록 개선 [이지수B]

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -17,8 +17,8 @@ export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // 쿠키에서 인증 토큰 확인
-  const authToken = request.cookies.get("accessToken")?.value;
-  
+  const authToken = request.cookies.get("refreshToken")?.value;
+
   // JWT 토큰에서 사용자 역할 추출
   const userRole = authToken ? getUserRoleFromToken(authToken) : null;
 
@@ -54,22 +54,20 @@ export function middleware(request: NextRequest) {
   if (isAuthenticated && userRole) {
     // 1. 일반유저(USER)가 접근할 수 없는 경로들
     const userRestrictedPaths = [
-      "/manage/users",      // 회원관리
-      "/manage/budgets",    // 예산관리
-      "/order-manage",      // 구매요청관리
-      "/order-history",     // 구매내역확인
+      "/manage/users", // 회원관리
+      "/manage/budgets", // 예산관리
+      "/order-manage", // 구매요청관리
+      "/order-history", // 구매내역확인
     ];
 
     // 2. 일반유저가 아닌 경우(ADMIN, SUPER_ADMIN) 접근할 수 없는 경로
     const nonUserRestrictedPaths = [
-      "/cart/order",              // 장바구니-주문
+      "/cart/order", // 장바구니-주문
     ];
 
     // 일반유저 제한 체크 (6개 경로: 회원관리, 예산관리, 구매요청관리, 구매요청관리상세, 구매내역확인, 구매내역확인상세)
     if (userRole === "USER") {
-      const isUserRestricted = userRestrictedPaths.some(path => 
-        pathname === path || pathname.startsWith(path + "/")
-      );
+      const isUserRestricted = userRestrictedPaths.some((path) => pathname === path || pathname.startsWith(path + "/"));
       if (isUserRestricted) {
         return NextResponse.redirect(new URL("/error", request.url));
       }
@@ -77,8 +75,8 @@ export function middleware(request: NextRequest) {
 
     // 일반유저가 아닌 경우 제한 체크 (장바구니-주문 접근 불가)
     if (userRole !== "USER") {
-      const isNonUserRestricted = nonUserRestrictedPaths.some(path => 
-        pathname === path || pathname.startsWith(path + "/")
+      const isNonUserRestricted = nonUserRestrictedPaths.some(
+        (path) => pathname === path || pathname.startsWith(path + "/"),
       );
       if (isNonUserRestricted) {
         return NextResponse.redirect(new URL("/error?from=order", request.url));
@@ -86,7 +84,7 @@ export function middleware(request: NextRequest) {
     }
   }
 
-    // 로그인한 사용자가 "/"로 접근하는 경우 /products로 리디렉션
+  // 로그인한 사용자가 "/"로 접근하는 경우 /products로 리디렉션
   if (pathname === "/" && isAuthenticated) {
     return NextResponse.redirect(new URL("/products", request.url));
   }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

> 어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
> 해당 작업을 파악하기 위한 개발 계획 문서, 피그마, QA 문서등의 링크를 첨부해주세요.
### 인증 미들웨어 개선: refreshToken 기반 인증 상태 판별

#### 문제점
기존 미들웨어는 `accessToken`의 존재 여부로 사용자의 인증 상태를 판단했습니다. 이로 인해 다음과 같은 문제가 발생했습니다:

1. **불필요한 리다이렉트**: `refreshToken`은 유효하지만 `accessToken`이 만료된 상태에서 보호된 라우트 접근 시, 미들웨어가 로그인 페이지로 강제 리다이렉트
2. **자동 토큰 갱신 차단**: `cookieFetch`의 자동 토큰 갱신 로직이 작동하기 전에 미들웨어에서 차단되어 사용자 경험 저하

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?

> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요


#### 해결책
미들웨어에서 인증 상태 판별 기준을 `refreshToken` 존재 여부로 변경:

```typescript
// Before: accessToken 기반 (문제가 있던 방식)
const authToken = request.cookies.get("accessToken")?.value;

// After: refreshToken 기반 (개선된 방식)  
const authToken = request.cookies.get("refreshToken")?.value;
```

#### ✅ 개선 효과
1. **자동 토큰 갱신 보장**: `refreshToken`이 유효한 사용자는 보호된 라우트에 접근 가능
2. **사용자 경험 향상**: 불필요한 로그인 페이지 리다이렉트 제거
3. **일관된 인증 플로우**: `cookieFetch`의 자동 토큰 갱신 로직과 미들웨어가 조화롭게 작동

### 🔄 동작 흐름
1. 사용자가 보호된 라우트 접근 시도
2. 미들웨어에서 `refreshToken` 존재 여부로 인증 상태 확인
3. `refreshToken`이 있으면 라우트 접근 허용
4. `cookieFetch`에서 API 요청 시 `accessToken` 만료 감지
5. 자동으로 `/auth/refresh-token` 엔드포인트 호출하여 `accessToken` 재발급
6. 원본 요청 재시도하여 정상적인 서비스 이용

이 변경으로 사용자는 `refreshToken`이 유효한 한 세션 만료 없이 서비스를 이용할 수 있으며, 백그라운드에서 자동으로 토큰이 갱신됩니다.

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?

> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 적어주세요

-

## 📌 PR 진행 시 이러한 점들을 참고해 주세요

- Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
- Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
- Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 3일 이내에 진행해 주세요.
- Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
  - P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
  - P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
  - P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
