### PR TITLE
fix: 주문 완료 및 주문 내역 상세 페이지 UI 개선 [장원빈]

### DIFF
--- a/src/app/(main)/cart/order-confirmed/[orderId]/page.tsx
+++ b/src/app/(main)/cart/order-confirmed/[orderId]/page.tsx
@@ -18,7 +18,7 @@ const ProductItem = React.memo(({ receipt }: { receipt: { price: number; quantit
   
   return (
     <div
-      className="self-stretch border-b border-primary-200 inline-flex justify-between items-center sm:py-5 sm:pr-5"
+      className="self-stretch border-b border-primary-200 inline-flex justify-between items-center pb-[8px] sm:py-5 sm:pr-5"
     >
       <div className="flex gap-5 flex-1 sm:flex sm:justify-start sm:items-center sm:gap-5">
         <div className="relative w-[72px] sm:w-[140px] h-[72px] sm:h-[140px] bg-primary-50 rounded-xs sm:bg-white flex justify-center items-center flex-shrink-0">
@@ -31,7 +31,7 @@ const ProductItem = React.memo(({ receipt }: { receipt: { price: number; quantit
             />
           </div>
         </div>
-        <div className="flex-1 inline-flex flex-col items-start gap-3 sm:justify-start sm:inline-flex sm:flex-col sm:justify-start sm:items-start sm:gap-7">
+        <div className="flex-1 inline-flex flex-col items-start gap-2 sm:justify-start sm:inline-flex sm:flex-col sm:justify-start sm:items-start sm:gap-7">
           <div className="flex flex-col justify-center items-start gap-1 sm:justify-start sm:gap-2.5">
             <div className="text-center justify-center text-primary-950 text-sm sm:text-base font-medium">
               {receipt.productName}
@@ -116,7 +116,7 @@ export default function OrderConfirmedPage() {
 
   // 버튼 텍스트 메모이제이션
   const buttonText = useMemo(() => {
-    return user?.role === "USER" ? "요청 내역 확인" : "구매 내역 확인";
+    return user?.role === "USER" ? "요청내역 확인" : "요청내역 확인";
   }, [user?.role]);
 
   // 진행 단계 컴포넌트 메모이제이션
@@ -273,12 +273,13 @@ export default function OrderConfirmedPage() {
 
           {/* 하단 버튼 */}
           <div className="self-stretch h-16 inline-flex justify-start md:justify-center items-center gap-5">
-            <Button
-              type="white"
-              label="장바구니로 돌아가기"
-              className="flex-1 md:flex-none md:w-[260px] h-16 px-4 py-3 bg-white rounded-[2px] outline-1 outline-offset-[-1px] outline-zinc-400 flex justify-center items-center text-base font-semibold"
+            <div
+              className="flex-1 md:flex-none md:w-[260px] h-16 px-4 py-3 bg-white rounded-[2px] outline-1 outline-offset-[-1px] outline-zinc-400 flex justify-center items-center text-base font-semibold cursor-pointer border border-zinc-400"
               onClick={handleBackToCart}
-            />
+            >
+              <span className="block sm:hidden text-center">장바구니</span>
+              <span className="hidden sm:block">장바구니로 돌아가기</span>
+            </div>
             <Button
               type="black"
               label={buttonText}

--- a/src/components/common/OrderDetail/ApprovalInfoSection.tsx
+++ b/src/components/common/OrderDetail/ApprovalInfoSection.tsx
@@ -50,26 +50,26 @@ export default function ApprovalInfoSection({
           </div>
         </div>
       </div>
-      <div className="self-stretch flex flex-col justify-center items-start sm:flex sm:flex-row sm:justify-start sm:items-stretch">
+      <div className="self-stretch flex flex-col justify-center items-center sm:flex sm:flex-row sm:justify-start sm:items-stretch">
         <div className="self-stretch inline-flex justify-start items-center sm:flex-1">
-          <div className="w-36 self-stretch px-2 py-4 border-r border-b border-primary-200 flex justify-start items-start gap-2">
+          <div className="w-36 h-12 px-2 py-2 border-r border-b border-primary-200 flex justify-start items-center gap-2">
             <div className="text-center justify-center text-primary-950 text-sm sm:text-base font-normal ">
               상태
             </div>
           </div>
-          <div className="flex-1 self-stretch p-4 border-b border-primary-200 flex justify-start items-start gap-2 sm:border-r">
+          <div className="flex-1 h-12 px-4 py-2 border-b border-primary-200 flex justify-start items-center gap-2 sm:border-r">
             <div className="text-center justify-center text-primary-900 text-sm sm:text-base font-bold ">
               {getStatusText(status)}
             </div>
           </div>
         </div>
-        <div className="self-stretch inline-flex justify-start items-start sm:flex-1">
-          <div className="w-36 self-stretch px-2 py-4 border-r border-b border-primary-200 flex justify-start items-start gap-2">
+        <div className="self-stretch inline-flex justify-start items-center sm:flex-1">
+          <div className="w-36 h-12 px-2 py-2 border-r border-b border-primary-200 flex justify-start items-center gap-2">
             <div className="text-center justify-center text-primary-950 text-sm sm:text-base font-normal ">
               결과 메시지
             </div>
           </div>
-          <div className="flex-1 self-stretch p-4 border-b border-primary-200 flex justify-start items-start gap-2">
+          <div className="flex-1 h-12 px-4 py-2 border-b border-primary-200 flex justify-start items-center gap-2">
             <div className="flex-1 justify-center text-primary-900 text-sm sm:text-base font-bold  leading-snug">
               {adminMessage || "-"}
             </div>

--- a/src/components/common/OrderDetail/OrderItemsSection.tsx
+++ b/src/components/common/OrderDetail/OrderItemsSection.tsx
@@ -68,7 +68,7 @@ export default function OrderItemsSection({
               {items.map((item: TProduct | TReceipt) => (
                 <div
                   key={item.id}
-                  className="self-stretch border-b border-primary-200 inline-flex justify-between items-center sm:py-5 sm:pr-5"
+                  className="self-stretch border-b border-primary-200 inline-flex justify-between items-center pb-[8px] sm:pb-0 sm:pr-5"
                 >
                   <div className="flex gap-5 flex-1 sm:flex sm:justify-start sm:items-center sm:gap-5">
                     <div className="w-[72px] sm:w-[140px] h-[72px] sm:h-[140px] bg-primary-50 rounded-xs sm:bg-white flex justify-center items-center flex-shrink-0">
@@ -83,7 +83,7 @@ export default function OrderItemsSection({
                         </div>
                       )}
                     </div>
-                    <div className="flex-1 inline-flex flex-col items-start gap-3 sm:justify-start sm:inline-flex sm:flex-col sm:justify-start sm:items-start sm:gap-7">
+                    <div className="flex-1 inline-flex flex-col items-start gap-2 sm:justify-start sm:inline-flex sm:flex-col sm:justify-start sm:items-start sm:gap-3">
                       <div className="flex flex-col justify-center items-start gap-1 sm:justify-start sm:gap-2.5">
                         <div className="text-center justify-center text-primary-950 text-sm sm:text-base font-medium">
                           {item.productName}

--- a/src/components/common/OrderDetail/RequestInfoSection.tsx
+++ b/src/components/common/OrderDetail/RequestInfoSection.tsx
@@ -51,13 +51,13 @@ export default function RequestInfoSection({
           </div>
         </div>
       </div>
-      <div className="self-stretch inline-flex justify-start items-start">
-        <div className="w-36 self-stretch px-2 py-4 border-r border-b border-primary-200 flex justify-start items-start gap-2">
+      <div className="self-stretch inline-flex justify-start items-center">
+        <div className="w-36 h-12 px-2 py-2 border-r border-b border-primary-200 flex justify-start items-center gap-2">
           <div className="text-center justify-center text-primary-950 text-sm sm:text-base font-normal ">
             요청 메시지
           </div>
         </div>
-        <div className="flex-1 self-stretch p-4 border-b border-primary-200 flex justify-start items-start gap-2">
+        <div className="flex-1 h-12 px-4 py-2 border-b border-primary-200 flex justify-start items-center gap-2">
           <div className="flex-1 justify-center text-primary-900 text-sm sm:text-base font-bold  leading-snug">
             {requestMessage || "요청 메시지가 없습니다."}
           </div>


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

> 어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
> 해당 작업을 파악하기 위한 개발 계획 문서, 피그마, QA 문서등의 링크를 첨부해주세요.

-주문 완료 페이지(`/cart/order-confirmed/[orderId]`)와 주문 내역 상세 페이지(`/order-history/[orderId]`)의 UI 일관성 및 사용자 경험을 개선하기 위한 작업입니다.

**문제점:**
- 상품 섹션의 수량과 가격 정보 간격이 너무 넓어 가독성이 떨어짐
- 상품 항목과 구분선 사이 간격이 부족하여 시각적으로 답답함
- 요청 메시지 구역의 세로 크기가 다른 섹션과 일치하지 않음
- 요청/승인 정보 섹션의 행 높이가 불규칙하고 텍스트 정렬이 일관성 없음
- 장바구니 버튼 텍스트가 모바일에서 길어져 가독성 저하

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?

> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요

### 1. 상품 섹션 레이아웃 최적화
- **수량/가격 간격 조정**: 모바일 8px, 데스크톱 12px로 최적화
- **하단 패딩 추가**: 모바일에서 상품 항목과 구분선 사이 간격 8px 추가

### 2. 요청 메시지 구역 개선
- **세로 크기 통일**: `h-40` (160px)로 고정하여 다른 섹션과 일관성 확보
- **오버플로우 처리**: `overflow-hidden`으로 내용이 넘치지 않도록 제어

### 3. 정보 섹션 행 높이 및 정렬 통일
- **행 높이 표준화**: 모든 행을 `h-12` (48px)로 통일
- **세로 중앙 정렬**: `items-center`로 텍스트를 세로 중앙에 정렬
- **패딩 최적화**: `py-2`로 상하 패딩을 균등하게 조정

### 4. 반응형 버튼 텍스트 구현
- **모바일**: "장바구니" (간결한 텍스트)
- **데스크톱**: "장바구니로 돌아가기" (상세한 설명)


## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?

> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 적어주세요

-

## 📌 PR 진행 시 이러한 점들을 참고해 주세요

- Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
- Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
- Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 3일 이내에 진행해 주세요.
- Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
  - P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
  - P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
  - P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
